### PR TITLE
chore: remove helix webhooks from events report

### DIFF
--- a/.github/ISSUE_TEMPLATE/events-bug-report.md
+++ b/.github/ISSUE_TEMPLATE/events-bug-report.md
@@ -1,8 +1,8 @@
 ---
-name: EventSub or Webhooks
-about: Report a bug related to EventSub or webhooks.
+name: EventSub
+about: Report a bug related to EventSub.
 title: ''
-labels: 'product: eventsub-webhooks'
+labels: 'product: eventsub'
 assignees: ''
 
 ---


### PR DESCRIPTION
helix webhooks are no longer a thing (and eventsub will cover both webhooks + websockets)

note: be sure to rename label after PR merge
